### PR TITLE
ci: update actions/checkout and actions/setup-go

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21
 


### PR DESCRIPTION
## Summary
* update actions/checkout to v4 to use node 20 runtime
  * v4 release notes: https://github.com/actions/checkout/releases/tag/v4.0.0
* update actions/setup-go to v5 to use node 20 runtime
  * v5 release notes: https://github.com/actions/setup-go/releases/tag/v5.0.0